### PR TITLE
Support for join packets and OTAA handshaking

### DIFF
--- a/lib/crypt.js
+++ b/lib/crypt.js
@@ -59,6 +59,53 @@ exports.decrypt = function(packet, AppSKey, NwkSKey) {
     return plaintextPayload;
 };
 
+exports.decryptJoin = function(packet, AppKey) {
+    var pktBufs = packet.getBuffers();
+    checkBuffer(pktBufs.MACPayloadWithMIC, "parsed packet");
+
+    checkBufferLength(AppKey, "AppKey", 16);
+
+    // TODO is there a better way to get cryptojs to ingest message/key?
+    var cipherstream = CryptoJS.AES.decrypt(
+        { ciphertext: CryptoJS.enc.Hex.parse(pktBufs.MACPayloadWithMIC.toString('hex')) },
+        CryptoJS.enc.Hex.parse(AppKey.toString('hex')), 
+        {
+            mode: CryptoJS.mode.ECB,
+            padding: CryptoJS.pad.NoPadding
+        }
+    );
+    return new Buffer(CryptoJS.enc.Hex.stringify(cipherstream), 'hex');
+};
+
+exports.generateSessionKeys = function(AppKey, NetId, AppNonce, DevNonce) {
+    checkBufferLength(AppKey, "AppKey", 16);
+    checkBufferLength(NetId, "NetId", 3);
+    checkBufferLength(AppNonce, "AppNonce", 3);
+    checkBufferLength(DevNonce, "DevNonce", 2);
+    var output = {};
+
+    // NwkSKey
+    var nwkSKeyNonce = Buffer.concat([new Buffer('01', 'hex'), util.reverse(AppNonce), util.reverse(NetId), util.reverse(DevNonce), new Buffer('00000000000000', 'hex')]);
+    var nwkSKey_base64 = CryptoJS.AES.encrypt(
+        CryptoJS.enc.Hex.parse(nwkSKeyNonce.toString('hex')),
+        CryptoJS.enc.Hex.parse(AppKey.toString('hex')), {
+            mode: CryptoJS.mode.ECB,
+            padding: CryptoJS.pad.NoPadding
+        });
+    output.NwkSKey = new Buffer(nwkSKey_base64.toString(), 'base64');
+
+    // AppSKey
+    var appSKeyNonce = Buffer.concat([new Buffer('02', 'hex'), util.reverse(AppNonce), util.reverse(NetId), util.reverse(DevNonce), new Buffer('00000000000000', 'hex')]);
+    var appSKey_base64 = CryptoJS.AES.encrypt(
+        CryptoJS.enc.Hex.parse(appSKeyNonce.toString('hex')),
+        CryptoJS.enc.Hex.parse(AppKey.toString('hex')), {
+            mode: CryptoJS.mode.ECB,
+            padding: CryptoJS.pad.NoPadding
+        });
+    output.AppSKey = new Buffer(appSKey_base64.toString(), 'base64');
+    return output;
+};
+
 
 // Encrypt stream mixes in metadata blocks, as Ai =
 //   0x01

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,39 +19,55 @@ module.exports={
 
     // deprecated
     getMIC:mic.calculateMIC,
-    create:packet.fromWire
+    create:packet.fromWire,
+
+    generateSessionKeys:crypt.generateSessionKeys
 };
 
 
 // to create a packet from fields, it's necessary to pull together
 //  all three modules (packet.js, mic.js, crypt.js)
-function _constructPacketFromFields(userFields, AppSKey, NwkSKey) {
+function _constructPacketFromFields(userFields, AppSKey, NwkSKey, AppKey) {
     // if user fails to supply keys, construct a packet anyway
     var constructed = packet.fromFields(userFields);
 
     if (constructed != null) {
-		if(constructed.isDataMessage() == true) {
-			// to encrypt, need NwkSKey if port=0, else AppSKey
-			if ((constructed.getFPort() == 0 && util.isBufferLength(NwkSKey, 16))
-				|| (constructed.getFPort() > 0 && util.isBufferLength(AppSKey, 16))) {
+        if(constructed.isDataMessage() == true) {
+            // to encrypt, need NwkSKey if port=0, else AppSKey
+            if ((constructed.getFPort() == 0 && util.isBufferLength(NwkSKey, 16))
+                || (constructed.getFPort() > 0 && util.isBufferLength(AppSKey, 16))) {
 
-				// crypto is reversible (just XORs FRMPayload), so we can
-				//  just do "decrypt" on the plaintext to get ciphertext
-				var ciphertext = crypt.decrypt(constructed, AppSKey, NwkSKey);
+                // crypto is reversible (just XORs FRMPayload), so we can
+                //  just do "decrypt" on the plaintext to get ciphertext
+                var ciphertext = crypt.decrypt(constructed, AppSKey, NwkSKey);
 
-				// overwrite payload with ciphertext
-				constructed.getBuffers().FRMPayload = ciphertext;
+                // overwrite payload with ciphertext
+                constructed.getBuffers().FRMPayload = ciphertext;
 
-				// recalculate buffers to be ready for MIC calc'n
-				constructed.mergeGroupFields();
-			}
-		}
+                // recalculate buffers to be ready for MIC calc'n
+                constructed.mergeGroupFields();
 
-        if (util.isBufferLength(NwkSKey, 16)) {
-            mic.recalculateMIC(constructed, NwkSKey);
-            constructed.mergeGroupFields();
+                if (util.isBufferLength(NwkSKey, 16)) {
+                    mic.recalculateMIC(constructed, NwkSKey, AppKey);
+                    constructed.mergeGroupFields();
+                }
+            }
+        } else if(constructed.isJoinRequestMessage() == true) {
+            if (util.isBufferLength(AppKey, 16)) {
+                mic.recalculateMIC(constructed, NwkSKey, AppKey);
+                constructed.mergeGroupFields();
+            }
+        } else if(constructed.isJoinAcceptMessage() == true) {
+            if (util.isBufferLength(AppKey, 16)) {
+                mic.recalculateMIC(constructed, NwkSKey, AppKey);
+                constructed.mergeGroupFields();
+
+                var ciphertext = crypt.decryptJoin(constructed, AppKey);
+
+                // overwrite payload with ciphertext
+                ciphertext.copy(constructed.getBuffers().MACPayloadWithMIC);
+            }
         }
     }
-
     return constructed;
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,20 +30,22 @@ function _constructPacketFromFields(userFields, AppSKey, NwkSKey) {
     var constructed = packet.fromFields(userFields);
 
     if (constructed != null) {
-        // to encrypt, need NwkSKey if port=0, else AppSKey
-        if ((constructed.getFPort() == 0 && util.isBufferLength(NwkSKey, 16))
-            || (constructed.getFPort() > 0 && util.isBufferLength(AppSKey, 16))) {
+		if(constructed.isDataMessage() == true) {
+			// to encrypt, need NwkSKey if port=0, else AppSKey
+			if ((constructed.getFPort() == 0 && util.isBufferLength(NwkSKey, 16))
+				|| (constructed.getFPort() > 0 && util.isBufferLength(AppSKey, 16))) {
 
-            // crypto is reversible (just XORs FRMPayload), so we can
-            //  just do "decrypt" on the plaintext to get ciphertext
-            var ciphertext = crypt.decrypt(constructed, AppSKey, NwkSKey);
+				// crypto is reversible (just XORs FRMPayload), so we can
+				//  just do "decrypt" on the plaintext to get ciphertext
+				var ciphertext = crypt.decrypt(constructed, AppSKey, NwkSKey);
 
-            // overwrite payload with ciphertext
-            constructed.getBuffers().FRMPayload = ciphertext;
+				// overwrite payload with ciphertext
+				constructed.getBuffers().FRMPayload = ciphertext;
 
-            // recalculate buffers to be ready for MIC calc'n
-            constructed.mergeGroupFields();
-        }
+				// recalculate buffers to be ready for MIC calc'n
+				constructed.mergeGroupFields();
+			}
+		}
 
         if (util.isBufferLength(NwkSKey, 16)) {
             mic.recalculateMIC(constructed, NwkSKey);

--- a/lib/mic.js
+++ b/lib/mic.js
@@ -32,63 +32,112 @@ var checkBuffer = util.checkBuffer;
 
 
 // calculate MIC from packet
-exports.calculateMIC = function (packet, NwkSKey) {
+exports.calculateMIC = function (packet, NwkSKey, AppKey) {
     var pktBufs = packet.getBuffers();
+    if(packet.isJoinRequestMessage() == true) {
+        checkBuffer(pktBufs.PHYPayload, "pktBufs packet");
+        checkBufferLength(AppKey, "AppKey", 16);
 
-    checkBuffer(pktBufs.PHYPayload, "pktBufs packet");
-    checkBufferLength(NwkSKey, "NwkSKey", 16);
+        checkBuffer(pktBufs.MHDR, "pktBufs packet.MHDR");
+        checkBuffer(pktBufs.AppEUI, "pktBufs packet.AppEUI");
+        checkBuffer(pktBufs.DevEUI, "pktBufs packet.DevEUI");
+        checkBuffer(pktBufs.DevNonce, "pktBufs packet.DevNonce");
 
-    checkBufferLength(pktBufs.DevAddr, "pktBufs packet.DevAddr", 4);
-    checkBufferLength(pktBufs.FCnt, "pktBufs packet.FCnt", 2);
+        var msglen = pktBufs.MHDR.length + pktBufs.AppEUI.length + pktBufs.DevEUI.length + pktBufs.DevNonce.length;
 
-    checkBuffer(pktBufs.MHDR, "pktBufs packet.MHDR");
-    checkBuffer(pktBufs.MACPayload, "pktBufs packet.MACPayload");
+        // CMAC over MHDR | AppEUI | DevEUI | DevNonce
+        // the seperate fields are not in little-endian format, use the concatenated field
+        var cmac_input = Buffer.concat([pktBufs.MHDR, pktBufs.MACPayload]);
 
-    var Dir;
-    if (packet.getDir() == 'up') {
-        Dir = util.bufferFromUInt8(0);
-    } else if (packet.getDir() == 'down') {
-        Dir = util.bufferFromUInt8(1);
+        // CMAC calculation (as RFC4493)
+        var full_cmac = aesCmac(AppKey, cmac_input, {returnAsBuffer: true});
+
+        // only first 4 bytes of CMAC are used as MIC
+        var MIC = full_cmac.slice(0,4);
+
+        return MIC;
+    } else if(packet.isJoinAcceptMessage() == true) {
+        checkBuffer(pktBufs.PHYPayload, "pktBufs packet");
+        checkBufferLength(AppKey, "AppKey", 16);
+
+        checkBuffer(pktBufs.MHDR, "pktBufs packet.MHDR");
+        checkBuffer(pktBufs.AppNonce, "pktBufs packet.AppNonce");
+        checkBuffer(pktBufs.NetID, "pktBufs packet.NetID");
+        checkBuffer(pktBufs.DevAddr, "pktBufs packet.DevAddr");
+        checkBuffer(pktBufs.DLSettings, "pktBufs packet.DLSettings");
+        checkBuffer(pktBufs.RxDelay, "pktBufs packet.RxDelay");
+        checkBuffer(pktBufs.CFList, "pktBufs packet.CFList");
+
+        var msglen = pktBufs.MHDR.length + pktBufs.AppNonce.length + pktBufs.NetID.length + pktBufs.DevAddr.length + 
+            pktBufs.DLSettings.length + pktBufs.RxDelay.length + pktBufs.CFList.length;
+
+        // CMAC over MHDR | AppNonce | NetID | DevAddr | DLSettings | RxDelay | CFList
+        // the seperate fields are not encrypted, use the encrypted concatenated field
+        var cmac_input = Buffer.concat([pktBufs.MHDR, pktBufs.MACPayload]);
+
+        // CMAC calculation (as RFC4493)
+        var full_cmac = aesCmac(AppKey, cmac_input, {returnAsBuffer: true});
+
+        // only first 4 bytes of CMAC are used as MIC
+        var MIC = full_cmac.slice(0,4);
+
+        return MIC;
     } else {
-        throw new Error (errHdr + "expecting direction to be either 'up' or 'down'");
+        checkBuffer(pktBufs.PHYPayload, "pktBufs packet");
+        checkBufferLength(NwkSKey, "NwkSKey", 16);
+
+        checkBufferLength(pktBufs.DevAddr, "pktBufs packet.DevAddr", 4);
+        checkBufferLength(pktBufs.FCnt, "pktBufs packet.FCnt", 2);
+
+        checkBuffer(pktBufs.MHDR, "pktBufs packet.MHDR");
+        checkBuffer(pktBufs.MACPayload, "pktBufs packet.MACPayload");
+
+        var Dir;
+        if (packet.getDir() == 'up') {
+            Dir = util.bufferFromUInt8(0);
+        } else if (packet.getDir() == 'down') {
+            Dir = util.bufferFromUInt8(1);
+        } else {
+            throw new Error (errHdr + "expecting direction to be either 'up' or 'down'");
+        }
+
+        var msglen = pktBufs.MHDR.length + pktBufs.MACPayload.length;
+
+        var B0 = Buffer.concat([
+            new Buffer("4900000000", 'hex'),    // as spec
+            Dir,  // direction ('Dir')
+            util.reverse(pktBufs.DevAddr),
+            util.reverse(pktBufs.FCnt),
+            util.bufferFromUInt16LE(0),    // upper 2 bytes of FCnt (zeroes)
+            util.bufferFromUInt8(0),    // 0x00
+            util.bufferFromUInt8(msglen)     // len(msg)
+            ]);
+
+        // CMAC over B0 | MHDR | MACPayload
+        var cmac_input = Buffer.concat([B0, pktBufs.MHDR, pktBufs.MACPayload]);
+
+        // CMAC calculation (as RFC4493)
+        var full_cmac = aesCmac(NwkSKey, cmac_input, {returnAsBuffer: true});
+
+        // only first 4 bytes of CMAC are used as MIC
+        var MIC = full_cmac.slice(0,4);
+
+        return MIC;
     }
-
-    var msglen = pktBufs.MHDR.length + pktBufs.MACPayload.length;
-
-    var B0 = Buffer.concat([
-        new Buffer("4900000000", 'hex'),    // as spec
-        Dir,  // direction ('Dir')
-        util.reverse(pktBufs.DevAddr),
-        util.reverse(pktBufs.FCnt),
-        util.bufferFromUInt16LE(0),    // upper 2 bytes of FCnt (zeroes)
-        util.bufferFromUInt8(0),    // 0x00
-        util.bufferFromUInt8(msglen)     // len(msg)
-        ]);
-
-    // CMAC over B0 | MHDR | MACPayload
-    var cmac_input = Buffer.concat([B0, pktBufs.MHDR, pktBufs.MACPayload]);
-
-    // CMAC calculation (as RFC4493)
-    var full_cmac = aesCmac(NwkSKey, cmac_input, {returnAsBuffer: true});
-
-    // only first 4 bytes of CMAC are used as MIC
-    var MIC = full_cmac.slice(0,4);
-
-    return MIC;
 };
 
 // verify is just calculate & compare
-exports.verifyMIC = function (packet, NwkSKey) {
+exports.verifyMIC = function (packet, NwkSKey, AppKey) {
     var pktBufs = packet.getBuffers();
     checkBufferLength(pktBufs.MIC, "pktBufs packet.MIC", 4);
 
-    var calculated = exports.calculateMIC(packet, NwkSKey);
+    var calculated = exports.calculateMIC(packet, NwkSKey, AppKey);
     return util.areBuffersEqual(pktBufs.MIC, calculated);
 };
 
 // calculate MIC & store
-exports.recalculateMIC = function (packet, NwkSKey) {
-    var calculated = exports.calculateMIC(packet, NwkSKey);
+exports.recalculateMIC = function (packet, NwkSKey, AppKey) {
+    var calculated = exports.calculateMIC(packet, NwkSKey, AppKey);
     var pktBufs = packet.getBuffers();
     pktBufs.MIC = calculated;
 };

--- a/lib/packet.js
+++ b/lib/packet.js
@@ -139,8 +139,8 @@ function LoraPacket(packetContents) {
             p.AppNonce = util.reverse(incoming.slice(1, 1 + 3));
             p.NetID = util.reverse(incoming.slice(4, 4 + 3));
             p.DevAddr = util.reverse(incoming.slice(7, 7 + 4));
-            p.DLSettings = incoming.readInt8(11);
-            p.RxDelay = incoming.readInt8(12);
+            p.DLSettings = incoming.slice(11, 11 + 1);
+            p.RxDelay = incoming.slice(12, 12 + 1);
             if (incoming.length == 13+16+4) {
                 p.CFList = incoming.slice(13, 13+16)
             } else {

--- a/lib/packet.js
+++ b/lib/packet.js
@@ -61,7 +61,13 @@ var constants = {
     FCTRL_ADR: 0x80,
     FCTRL_ADRACKREQ: 0x40,
     FCTRL_ACK: 0x20,
-    FCTRL_FPENDING: 0x10
+    FCTRL_FPENDING: 0x10,
+    DLSETTINGS_RXONEDROFFSET_MASK: 0x70,
+    DLSETTINGS_RXONEDROFFSET_POS: 4,
+    DLSETTINGS_RXTWODATARATE_MASK: 0x0F,
+    DLSETTINGS_RXTWODATARATE_POS: 0,
+    RXDELAY_DEL_MASK: 0x0F,
+    RXDELAY_DEL_POS: 0
 };
 
 exports.constants = function() {
@@ -377,6 +383,66 @@ function LoraPacket(packetContents) {
         return !!(that._packet.FCtrl.readUInt8(0) & constants.FCTRL_FPENDING);
     };
 
+    // provide DLSettings.RX1DRoffset as integer
+    this.getDLSettingsRxOneDRoffset = function() {
+        return (that._packet.DLSettings.readUInt8(0) & constants.DLSETTINGS_RXONEDROFFSET_MASK) >> constants.DLSETTINGS_RXONEDROFFSET_POS;
+    };
+
+    // provide DLSettings.RX2DataRate as integer
+    this.getDLSettingsRxTwoDataRate = function() {
+        return (that._packet.DLSettings.readUInt8(0) & constants.DLSETTINGS_RXTWODATARATE_MASK) >> constants.DLSETTINGS_RXTWODROFFSET_POS;
+    };
+
+    // provide RxDelay.Del as integer
+    this.getRxDelayDel = function() {
+        return (that._packet.RxDelay.readUInt8(0) & constants.RXDELAY_DEL_MASK) >> constants.RXDELAY_DEL_POS;
+    };
+
+    // provide CFList.FreqChFour as buffer
+    this.getCFListFreqChFour = function() {
+        if(that._packet.CFList.length === 16) {
+            return that._packet.CFList.slice(0, 0 + 3);
+        } else {
+            return new Buffer(0);
+        }
+    };
+
+    // provide CFList.FreqChFive as buffer
+    this.getCFListFreqChFive = function() {
+        if(that._packet.CFList.length === 16) {
+            return that._packet.CFList.slice(3, 3 + 3);
+        } else {
+            return new Buffer(0);
+        }
+    };
+
+    // provide CFList.FreqChSix as buffer
+    this.getCFListFreqChSix = function() {
+        if(that._packet.CFList.length === 16) {
+            return that._packet.CFList.slice(6, 6 + 3);
+        } else {
+            return new Buffer(0);
+        }
+    };
+
+    // provide CFList.FreqChSeven as buffer
+    this.getCFListFreqChSeven = function() {
+        if(that._packet.CFList.length === 16) {
+            return that._packet.CFList.slice(9, 9 + 3);
+        } else {
+            return new Buffer(0);
+        }
+    };
+
+    // provide CFList.FreqChEight as buffer
+    this.getCFListFreqChEight = function() {
+        if(that._packet.CFList.length === 16) {
+            return that._packet.CFList.slice(12, 12 + 3);
+        } else {
+            return new Buffer(0);
+        }
+    };
+
     this.getPHYPayload = function() {
         return that._packet.PHYPayload;
     };
@@ -400,43 +466,63 @@ function LoraPacket(packetContents) {
         var msg = "";
 
         if (that.isJoinRequestMessage()) {
-            msg += "Message Type = Join Request" + "\n";
-            msg += "      AppEUI = " + asHexString(p.AppEUI) + "\n";
-            msg += "      DevEUI = " + asHexString(p.DevEUI) + "\n";
-            msg += "    DevNonce = " + asHexString(p.DevNonce) + "\n";
-            msg += "         MIC = " + asHexString(p.MIC) + "\n";
+            msg += "          Message Type = Join Request" + "\n";
+            msg += "            PHYPayload = " + asHexString(p.PHYPayload).toUpperCase() + "\n";
+            msg += "\n";
+            msg += "          ( PHYPayload = AppEUI[8] | DevEUI[8] | DevNonce[2] | MIC[4] )\n";
+            msg += "                AppEUI = " + asHexString(p.AppEUI) + "\n";
+            msg += "                DevEUI = " + asHexString(p.DevEUI) + "\n";
+            msg += "              DevNonce = " + asHexString(p.DevNonce) + "\n";
+            msg += "                   MIC = " + asHexString(p.MIC) + "\n";
         } else if (that.isJoinAcceptMessage()) {
-            msg += "Message Type = Join Accept" + "\n";
-            msg += "    AppNonce = " + asHexString(p.AppNonce) + "\n";
-            msg += "       NetID = " + asHexString(p.NetID) + "\n";
-            msg += "     DevAddr = " + asHexString(p.DevAddr) + "\n";
-            // TODO & the rest
-            msg += "         MIC = " + asHexString(p.MIC) + "\n";
+            msg += "          Message Type = Join Accept" + "\n";
+            msg += "\n";
+            msg += "          ( PHYPayload = AppNonce[2] | NetID[2] | DevAddr[4] | DLSettings[1] | RxDelay[1] | CFList[0|15] | MIC[4] )\n";
+            msg += "              AppNonce = " + asHexString(p.AppNonce) + "\n";
+            msg += "                 NetID = " + asHexString(p.NetID) + "\n";
+            msg += "               DevAddr = " + asHexString(p.DevAddr) + "\n";
+            msg += "            DLSettings = " + asHexString(p.DLSettings) + "\n";
+            msg += "               RxDelay = " + asHexString(p.RxDelay) + "\n";
+            msg += "                CFList = " + asHexString(p.CFList) + "\n";
+            msg += "                   MIC = " + asHexString(p.MIC) + "\n";
+            msg += "\n";
+            msg += "DLSettings.RX1DRoffset = " + that.getRxOneDRoffset() + "\n";
+            msg += "DLSettings.RX2DataRate = " + that.getRxTwoDataRate() + "\n";
+            msg += "           RxDelay.Del = " + that.getRxDelayDel() + "\n";
+            msg += "\n";
+            if(p.CFList.length === 15) {
+                msg += "              ( CFList = FreqCh4[3] | FreqCh5[3] | FreqCh6[3] | FreqCh7[3] | FreqCh8[3] )\n";
+                msg += "               FreqCh4 = " + asHexString(that.getCFListFreqChFour) + "\n";
+                msg += "               FreqCh5 = " + asHexString(that.getCFListFreqChFive) + "\n";
+                msg += "               FreqCh6 = " + asHexString(that.getCFListFreqChSix) + "\n";
+                msg += "               FreqCh7 = " + asHexString(that.getCFListFreqChSeven) + "\n";
+                msg += "               FreqCh8 = " + asHexString(that.getCFListFreqChEight) + "\n";
+            }
         } else if (that.isDataMessage()) {
             msg += "Message Type = Data" + "\n";
-            msg += "  PHYPayload = " + asHexString(p.PHYPayload).toUpperCase() + "\n";
+            msg += "            PHYPayload = " + asHexString(p.PHYPayload).toUpperCase() + "\n";
             msg += "\n";
-            msg += "( PHYPayload = MHDR[1] | MACPayload[..] | MIC[4] )\n";
-            msg += "        MHDR = " + asHexString(p.MHDR) + "\n";
-            msg += "  MACPayload = " + asHexString(p.MACPayload) + "\n";
-            msg += "         MIC = " + asHexString(p.MIC) + "\n";
+            msg += "          ( PHYPayload = MHDR[1] | MACPayload[..] | MIC[4] )\n";
+            msg += "                  MHDR = " + asHexString(p.MHDR) + "\n";
+            msg += "            MACPayload = " + asHexString(p.MACPayload) + "\n";
+            msg += "                   MIC = " + asHexString(p.MIC) + "\n";
             msg += "\n";
-            msg += "( MACPayload = FHDR | FPort | FRMPayload )\n";
-            msg += "        FHDR = " + asHexString(p.FHDR) + "\n";
-            msg += "       FPort = " + asHexString(p.FPort) + "\n";
-            msg += "  FRMPayload = " + asHexString(p.FRMPayload) + "\n";
+            msg += "          ( MACPayload = FHDR | FPort | FRMPayload )\n";
+            msg += "                  FHDR = " + asHexString(p.FHDR) + "\n";
+            msg += "                 FPort = " + asHexString(p.FPort) + "\n";
+            msg += "            FRMPayload = " + asHexString(p.FRMPayload) + "\n";
             msg += "\n";
-            msg += "      ( FHDR = DevAddr[4] | FCtrl[1] | FCnt[2] | FOpts[0..15] )\n";
-            msg += "     DevAddr = " + asHexString(p.DevAddr) + " (Big Endian)\n";
-            msg += "       FCtrl = " + asHexString(p.FCtrl) + "\n"; //TODO as binary?
-            msg += "        FCnt = " + asHexString(p.FCnt) + " (Big Endian)\n";
-            msg += "       FOpts = " + asHexString(p.FOpts) + "\n";
+            msg += "                ( FHDR = DevAddr[4] | FCtrl[1] | FCnt[2] | FOpts[0..15] )\n";
+            msg += "               DevAddr = " + asHexString(p.DevAddr) + " (Big Endian)\n";
+            msg += "                 FCtrl = " + asHexString(p.FCtrl) + "\n"; //TODO as binary?
+            msg += "                  FCnt = " + asHexString(p.FCnt) + " (Big Endian)\n";
+            msg += "                 FOpts = " + asHexString(p.FOpts) + "\n";
             msg += "\n";
-            msg += "Message Type = " + that.getMType() + "\n";
-            msg += "   Direction = " + that.getDir() + "\n";
-            msg += "        FCnt = " + that.getFCnt() + "\n";
-            msg += "   FCtrl.ACK = " + that.getFCtrlACK() + "\n";
-            msg += "   FCtrl.ADR = " + that.getFCtrlADR() + "\n";
+            msg += "          Message Type = " + that.getMType() + "\n";
+            msg += "             Direction = " + that.getDir() + "\n";
+            msg += "                  FCnt = " + that.getFCnt() + "\n";
+            msg += "             FCtrl.ACK = " + that.getFCtrlACK() + "\n";
+            msg += "             FCtrl.ADR = " + that.getFCtrlADR() + "\n";
         }
         return msg;
     };

--- a/lib/packet.js
+++ b/lib/packet.js
@@ -246,7 +246,7 @@ function LoraPacket(packetContents) {
                 p.FCnt = new Buffer(userFields.FCnt);
             } else if (util.isNumber(userFields.FCnt)) {
                 p.FCnt = new Buffer(2);
-                p.FCnt.writeInt16BE(userFields.FCnt, 0); // NB bigendian
+                p.FCnt.writeUInt16BE(userFields.FCnt, 0); // NB bigendian
             }
         }
 

--- a/lib/packet.js
+++ b/lib/packet.js
@@ -137,11 +137,15 @@ function LoraPacket(packetContents) {
         //        var type = p.MHDR._getMType;
         if (that.isJoinRequestMessage()) {
             // NB little-endian buffers!
+            p.MACPayload = incoming.slice(1, incoming.length - 4);
+            p.MACPayloadWithMIC = incoming.slice(1, incoming.length);
             p.AppEUI = util.reverse(incoming.slice(1, 1 + 8));
             p.DevEUI = util.reverse(incoming.slice(9, 9 + 8));
             p.DevNonce = util.reverse(incoming.slice(17, 17 + 2));
             p.MIC = incoming.slice(incoming.length - 4);
         } else if (that.isJoinAcceptMessage()) {
+            p.MACPayload = incoming.slice(1, incoming.length - 4);
+            p.MACPayloadWithMIC = incoming.slice(1, incoming.length);
             p.AppNonce = util.reverse(incoming.slice(1, 1 + 3));
             p.NetID = util.reverse(incoming.slice(4, 4 + 3));
             p.DevAddr = util.reverse(incoming.slice(7, 7 + 4));
@@ -155,6 +159,7 @@ function LoraPacket(packetContents) {
             p.MIC = incoming.slice(incoming.length - 4);
         } else if (that.isDataMessage()) {
             p.MACPayload = incoming.slice(1, incoming.length - 4);
+            p.MACPayloadWithMIC = incoming.slice(1, incoming.length);
             p.MIC = incoming.slice(incoming.length - 4);
 
             p.FCtrl = p.MACPayload.slice(4, 5);
@@ -442,7 +447,7 @@ function LoraPacket(packetContents) {
         if (util.isDefined(userFields.DLSettings)) {
             if (util.isBufferLength(userFields.DLSettings, 1)) {
                 p.DLSettings = new Buffer(userFields.DLSettings);
-            } else if (util.isNumber(userFields.FCnt)) {
+            } else if (util.isNumber(userFields.DLSettings)) {
                 p.DLSettings = new Buffer(1);
                 p.DLSettings.writeUInt8(userFields.DLSettings, 0);
             } else {
@@ -453,7 +458,7 @@ function LoraPacket(packetContents) {
         if (util.isDefined(userFields.RxDelay)) {
             if (util.isBufferLength(userFields.RxDelay, 1)) {
                 p.RxDelay = new Buffer(userFields.RxDelay);
-            } else if (util.isNumber(userFields.FCnt)) {
+            } else if (util.isNumber(userFields.RxDelay)) {
                 p.RxDelay = new Buffer(1);
                 p.RxDelay.writeUInt8(userFields.RxDelay, 0);
             } else {
@@ -462,7 +467,7 @@ function LoraPacket(packetContents) {
         }
 
         if (util.isDefined(userFields.CFList)) {
-            if (util.isBufferLength(userFields.CFList, 16)) {
+            if (util.isBufferLength(userFields.CFList, 0) || util.isBufferLength(userFields.CFList, 16)) {
                 p.CFList = new Buffer(userFields.CFList);
             } else {
                 throw new Error("CFList is required in a suitable format");
@@ -537,13 +542,18 @@ function LoraPacket(packetContents) {
     this.mergeGroupFields = function() {
         var p = that._packet;
         if(that.isJoinRequestMessage()) {
-            p.PHYPayload = Buffer.concat([p.MHDR, util.reverse(p.AppEUI), util.reverse(p.DevEUI), util.reverse(p.DevNonce), p.MIC]);
+            p.MACPayload = Buffer.concat([util.reverse(p.AppEUI), util.reverse(p.DevEUI), util.reverse(p.DevNonce)]);
+            p.PHYPayload = Buffer.concat([p.MHDR, p.MACPayload, p.MIC]);
+            p.MACPayloadWithMIC = p.PHYPayload.slice(p.MHDR.length, p.PHYPayload.length);
         } else if(that.isJoinAcceptMessage()) {
-            p.PHYPayload = Buffer.concat([p.MHDR, util.reverse(p.AppNonce), util.reverse(p.NetID), util.reverse(p.DevAddr), p.DLSettings, p.RxDelay, p.CFList, p.MIC]);
+            p.MACPayload = Buffer.concat([util.reverse(p.AppNonce), util.reverse(p.NetID), util.reverse(p.DevAddr), p.DLSettings, p.RxDelay, p.CFList]);
+            p.PHYPayload = Buffer.concat([p.MHDR, p.MACPayload, p.MIC]);
+            p.MACPayloadWithMIC = p.PHYPayload.slice(p.MHDR.length, p.PHYPayload.length);
         } else {
             p.FHDR = Buffer.concat([util.reverse(p.DevAddr), p.FCtrl, util.reverse(p.FCnt), p.FOpts]);
             p.MACPayload = Buffer.concat([p.FHDR, p.FPort, p.FRMPayload]);
             p.PHYPayload = Buffer.concat([p.MHDR, p.MACPayload, p.MIC]);
+            p.MACPayloadWithMIC = p.PHYPayload.slice(p.MHDR.length, p.PHYPayload.length);
         }
     };
 

--- a/lib/packet.js
+++ b/lib/packet.js
@@ -187,22 +187,52 @@ function LoraPacket(packetContents) {
     };
 
 
+    function _isPlausibleDataPacket(userFields) {
+        if (
+            util.isDefined(userFields.DevAddr) && util.isDefined(userFields.payload)
+        ) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    function _isPlausibleJoinRequestPacket(userFields) {
+        if (
+            util.isDefined(userFields.AppEUI) && util.isDefined(userFields.DevEUI) && util.isDefined(userFields.DevNonce)
+        ) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    function _isPlausibleJoinAcceptPacket(userFields) {
+        if (
+            util.isDefined(userFields.AppNonce) && util.isDefined(userFields.NetID) && util.isDefined(userFields.DevAddr)
+        ) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
     function _isPlausible(userFields) {
         if (!util.isDefined(userFields)) {
             return false;
-        } else if (
-            util.isDefined(userFields.payload) && util.isDefined(userFields.DevAddr)
-        ) {
-            return true;
+        } else if (_isPlausibleDataPacket(userFields) === true) {
+            return true
+        } else if (_isPlausibleJoinRequestPacket(userFields) === true) {
+            return true
+        } else if (_isPlausibleJoinAcceptPacket(userFields) === true) {
+            return true
         } else {
             // not enough to construct packet
             return false;
         }
     }
 
-    // populate anew from whatever the client gives us
-    //  with defaults for the rest
-    function _initialiseFromFields(userFields) {
+    function _initialiseDataPacketFromFields(userFields) {
         var p = {}; // temp packet we use during construction
         that._packet = null;
 
@@ -210,10 +240,10 @@ function LoraPacket(packetContents) {
         if (util.isBufferLength(userFields.DevAddr, 4)) {
             p.DevAddr = new Buffer(userFields.DevAddr);
         } else {
-            return null;
+            throw new Error("DevAddr is required in a suitable format");
         }
 
-        // required fields:
+        // required fields
         if (util.isDefined(userFields.payload)) {
             if (util.isString(userFields.payload)) {
                 // construct from string
@@ -225,10 +255,10 @@ function LoraPacket(packetContents) {
                 // TODO: construct from Uint8Array
                 p.FRMPayload = new Buffer("TODO");
             } else {
-                return null; // payload is required in suitable format
+                throw new Error("Payload is required in a suitable format");
             }
         } else {
-            return null; // payload is required
+            throw new Error("Payload is required (but may be empty)");
         }
 
 
@@ -241,9 +271,11 @@ function LoraPacket(packetContents) {
                 if (mhdr_idx >= 0) {
                     p.MHDR = new Buffer(1);
                     p.MHDR.writeUInt8(mhdr_idx << 5, 0);
+                } else {
+                    throw new Error("MType is unknown");
                 }
             } else {
-                return null; // bogus
+                throw new Error("MType is required in a suitable format");
             }
         }
 
@@ -253,6 +285,8 @@ function LoraPacket(packetContents) {
             } else if (util.isNumber(userFields.FCnt)) {
                 p.FCnt = new Buffer(2);
                 p.FCnt.writeUInt16BE(userFields.FCnt, 0); // NB bigendian
+            } else {
+                throw new Error("FCnt is required in a suitable format");
             }
         }
 
@@ -262,9 +296,11 @@ function LoraPacket(packetContents) {
                 p.FOpts = new Buffer(userFields.FOpts, 'hex');
             } else if (util.isBuffer(userFields.FOpts)) {
                 p.FOpts = new Buffer(userFields.FOpts);
+            } else {
+                throw new Error("FOpts is required in a suitable format");
             }
             if (15 < p.FOpts.length) {
-                return null; // Too many options fo piggybacked
+                throw new Error("Too many options for piggybacking");
             }
         } else {
             p.FOpts = new Buffer('', 'hex');
@@ -294,7 +330,7 @@ function LoraPacket(packetContents) {
                 p.FPort = new Buffer(1);
                 p.FPort.writeUInt8(userFields.FPort, 0);
             } else {
-                return null; // bogus
+                throw new Error("FPort required in a suitable format");
             }
         }
 
@@ -328,15 +364,187 @@ function LoraPacket(packetContents) {
         that.mergeGroupFields();
     }
 
+    function _initialiseJoinRequestPacketFromFields(userFields) {
+        var p = {}; // temp packet we use during construction
+        that._packet = null;
+
+        // required fields
+        if (util.isBufferLength(userFields.AppEUI, 8)) {
+            p.AppEUI = new Buffer(userFields.AppEUI);
+        } else {
+            throw new Error("AppEUI is required in a suitable format");
+        }
+
+        // required fields
+        if (util.isBufferLength(userFields.DevEUI, 8)) {
+            p.DevEUI = new Buffer(userFields.DevEUI);
+        } else {
+            throw new Error("DevEUI is required in a suitable format");
+        }
+
+        // required fields
+        if (util.isBufferLength(userFields.DevNonce, 2)) {
+            p.DevNonce = new Buffer(userFields.DevNonce);
+        } else {
+            throw new Error("DevNonce is required in a suitable format");
+        }
+
+
+        if (util.isDefined(userFields.FCnt)) {
+            if (util.isBufferLength(userFields.FCnt, 2)) {
+                p.FCnt = new Buffer(userFields.FCnt);
+            } else if (util.isNumber(userFields.FCnt)) {
+                p.FCnt = new Buffer(2);
+                p.FCnt.writeUInt16BE(userFields.FCnt, 0); // NB bigendian
+            } else {
+                throw new Error("FCnt is required in a suitable format");
+            }
+        }
+        p.MHDR = new Buffer(1);
+        p.MHDR.writeUInt8(constants.MTYPE_JOIN_REQUEST << 5, 0);
+
+
+        // this MIC is bogus for now, but correct length
+        if (!util.isDefined(p.MIC)) {
+            p.MIC = new Buffer('EEEEEEEE', 'hex');
+        }
+
+        that._packet = p;
+        that.mergeGroupFields();
+    }
+
+    function _initialiseJoinAcceptPacketFromFields(userFields) {
+        var p = {}; // temp packet we use during construction
+        that._packet = null;
+
+        // required fields
+        if (util.isBufferLength(userFields.AppNonce, 3)) {
+            p.AppNonce = new Buffer(userFields.AppNonce);
+        } else {
+            throw new Error("AppNonce is required in a suitable format");
+        }
+
+        // required fields
+        if (util.isBufferLength(userFields.NetID, 3)) {
+            p.NetID = new Buffer(userFields.NetID);
+        } else {
+            throw new Error("NetID is required in a suitable format");
+        }
+
+        // required fields
+        if (util.isBufferLength(userFields.DevAddr, 4)) {
+            p.DevAddr = new Buffer(userFields.DevAddr);
+        } else {
+            throw new Error("DevAddr is required in a suitable format");
+        }
+
+
+        if (util.isDefined(userFields.DLSettings)) {
+            if (util.isBufferLength(userFields.DLSettings, 1)) {
+                p.DLSettings = new Buffer(userFields.DLSettings);
+            } else if (util.isNumber(userFields.FCnt)) {
+                p.DLSettings = new Buffer(1);
+                p.DLSettings.writeUInt8(userFields.DLSettings, 0);
+            } else {
+                throw new Error("DLSettings is required in a suitable format");
+            }
+        }
+
+        if (util.isDefined(userFields.RxDelay)) {
+            if (util.isBufferLength(userFields.RxDelay, 1)) {
+                p.RxDelay = new Buffer(userFields.RxDelay);
+            } else if (util.isNumber(userFields.FCnt)) {
+                p.RxDelay = new Buffer(1);
+                p.RxDelay.writeUInt8(userFields.RxDelay, 0);
+            } else {
+                throw new Error("RxDelay is required in a suitable format");
+            }
+        }
+
+        if (util.isDefined(userFields.CFList)) {
+            if (util.isBufferLength(userFields.CFList, 16)) {
+                p.CFList = new Buffer(userFields.CFList);
+            } else {
+                throw new Error("CFList is required in a suitable format");
+            }
+        }
+
+
+        if (!util.isDefined(p.DLSettings)) {
+            p.DLSettings = new Buffer('00', 'hex');
+        }
+        if (!util.isDefined(p.RxDelay)) {
+            p.RxDelay = new Buffer('00', 'hex');
+        }
+        if (!util.isDefined(p.CFList)) {
+            p.CFList = new Buffer('', 'hex');
+        }
+        p.MHDR = new Buffer(1);
+        p.MHDR.writeUInt8(constants.MTYPE_JOIN_ACCEPT << 5, 0);
+
+
+        // this MIC is bogus for now, but correct length
+        if (!util.isDefined(p.MIC)) {
+            p.MIC = new Buffer('EEEEEEEE', 'hex');
+        }
+
+        that._packet = p;
+        that.mergeGroupFields();
+    }
+
+    // populate anew from whatever the client gives us
+    //  with defaults for the rest
+    function _initialiseFromFields(userFields) {
+        if (util.isDefined(userFields.MType)) {
+            var MTypeNo;
+            if (util.isNumber(userFields.MType)) {
+                MTypeNo = userFields.MType;
+            } else if (util.isString(userFields.MType)) {
+                var mhdr_idx = constants.MTYPE_DESCRIPTIONS.indexOf(userFields.MType);
+                if (mhdr_idx >= 0) {
+                    MTypeNo = mhdr_idx;
+                } else {
+                    throw new Error("MType is unknown");
+                }
+            } else {
+                throw new Error("MType is required in a suitable format");
+            }
+
+            if(MTypeNo == constants.MTYPE_JOIN_REQUEST) {
+                _initialiseJoinRequestPacketFromFields(userFields);
+            } else if(MTypeNo == constants.MTYPE_JOIN_ACCEPT) {
+                _initialiseJoinAcceptPacketFromFields(userFields);
+            } else {
+                _initialiseDataPacketFromFields(userFields);
+            }
+        } else {
+            if (_isPlausibleDataPacket(userFields) === true) {
+                _initialiseDataPacketFromFields(userFields);
+            } else if (_isPlausibleJoinRequestPacket(userFields) === true) {
+                _initialiseJoinRequestPacketFromFields(userFields);
+            } else if (_isPlausibleJoinAcceptPacket(userFields) === true) {
+                _initialiseJoinAcceptPacketFromFields(userFields);
+            } else {
+                throw new Error("No plausible packet");
+            }
+        }
+    }
+
     // packet creation (or re-creation)
     // - merge individual fields to create the higher-level ones
     //  (e.g PHYPayload = MHDR | MACPayload  | MIC)
     // BUT note that DevAddr & FCnt are stored big-endian
     this.mergeGroupFields = function() {
         var p = that._packet;
-        p.FHDR = Buffer.concat([util.reverse(p.DevAddr), p.FCtrl, util.reverse(p.FCnt), p.FOpts]);
-        p.MACPayload = Buffer.concat([p.FHDR, p.FPort, p.FRMPayload]);
-        p.PHYPayload = Buffer.concat([p.MHDR, p.MACPayload, p.MIC]);
+        if(that.isJoinRequestMessage()) {
+            p.PHYPayload = Buffer.concat([p.MHDR, util.reverse(p.AppEUI), util.reverse(p.DevEUI), util.reverse(p.DevNonce), p.MIC]);
+        } else if(that.isJoinAcceptMessage()) {
+            p.PHYPayload = Buffer.concat([p.MHDR, util.reverse(p.AppNonce), util.reverse(p.NetID), util.reverse(p.DevAddr), p.DLSettings, p.RxDelay, p.CFList, p.MIC]);
+        } else {
+            p.FHDR = Buffer.concat([util.reverse(p.DevAddr), p.FCtrl, util.reverse(p.FCnt), p.FOpts]);
+            p.MACPayload = Buffer.concat([p.FHDR, p.FPort, p.FRMPayload]);
+            p.PHYPayload = Buffer.concat([p.MHDR, p.MACPayload, p.MIC]);
+        }
     };
 
     // provide MType as a string

--- a/test/test_construct.js
+++ b/test/test_construct.js
@@ -289,6 +289,117 @@ module.exports = function () {
             expect(packet.getFCtrlFPending()).to.equal(true);
         });
 
+
+        it('should create join request packet', function () {
+            var packet = lora_packet.fromFields(
+                {
+                    AppEUI: new Buffer('AABBCCDDAABBCCDD', 'hex'),
+                    DevEUI: new Buffer('AABBCCDDAABBCCDD', 'hex'),
+                    DevNonce: new Buffer('AABB', 'hex')
+                });
+            var expected_pktBufs = {
+                PHYPayload: new Buffer('00DDCCBBAADDCCBBAADDCCBBAADDCCBBAABBAAeeeeeeee', 'hex'),
+                MHDR: new Buffer('00', 'hex'),
+                MIC: new Buffer('EEEEEEEE', 'hex'),
+				AppEUI: new Buffer('AABBCCDDAABBCCDD', 'hex'),
+				DevEUI: new Buffer('AABBCCDDAABBCCDD', 'hex'),
+				DevNonce: new Buffer('AABB', 'hex')
+            };
+            expect(packet).not.to.be.null;
+            expect(packet.getBuffers()).to.not.be.undefined;
+            expect(packet.getBuffers()).to.deep.equal(expected_pktBufs);
+
+            // re-parse to cross-check
+            var parsed = lora_packet.fromWire(expected_pktBufs.PHYPayload);
+            expect(parsed.getBuffers()).to.deep.equal(expected_pktBufs);
+        });
+
+        it('should create join accept packet with minimal input', function () {
+            var packet = lora_packet.fromFields(
+                {
+                    AppNonce: new Buffer('AABBCC', 'hex'),
+                    NetID: new Buffer('AABBCC', 'hex'),
+                    DevAddr: new Buffer('AABBCCDD', 'hex')
+                });
+            var expected_pktBufs = {
+                PHYPayload: new Buffer('20CCBBAACCBBAADDCCBBAA0000eeeeeeee', 'hex'),
+                MHDR: new Buffer('20', 'hex'),
+                MIC: new Buffer('EEEEEEEE', 'hex'),
+				AppNonce: new Buffer('AABBCC', 'hex'),
+				NetID: new Buffer('AABBCC', 'hex'),
+				DevAddr: new Buffer('AABBCCDD', 'hex'),
+				DLSettings: new Buffer('00', 'hex'),
+				RxDelay: new Buffer('00', 'hex'),
+				CFList: new Buffer(0)
+            };
+            expect (packet).not.to.be.null;
+            expect(packet.getBuffers()).to.not.be.undefined;
+            expect(packet.getBuffers()).to.deep.equal(expected_pktBufs);
+
+            // re-parse to cross-check
+            var parsed = lora_packet.fromWire(expected_pktBufs.PHYPayload);
+            expect(parsed.getBuffers()).to.deep.equal(expected_pktBufs);
+        });
+
+        it('should create join accept packet', function () {
+            var packet = lora_packet.fromFields(
+                {
+                    AppNonce: new Buffer('AABBCC', 'hex'),
+                    NetID: new Buffer('AABBCC', 'hex'),
+                    DevAddr: new Buffer('AABBCCDD', 'hex'),
+					DLSettings: new Buffer('12', 'hex'),
+					RxDelay: new Buffer('0F', 'hex')
+                });
+            var expected_pktBufs = {
+                PHYPayload: new Buffer('20CCBBAACCBBAADDCCBBAA120Feeeeeeee', 'hex'),
+                MHDR: new Buffer('20', 'hex'),
+                MIC: new Buffer('EEEEEEEE', 'hex'),
+				AppNonce: new Buffer('AABBCC', 'hex'),
+				NetID: new Buffer('AABBCC', 'hex'),
+				DevAddr: new Buffer('AABBCCDD', 'hex'),
+				DLSettings: new Buffer('12', 'hex'),
+				RxDelay: new Buffer('0F', 'hex'),
+				CFList: new Buffer(0)
+            };
+            expect (packet).not.to.be.null;
+            expect(packet.getBuffers()).to.not.be.undefined;
+            expect(packet.getBuffers()).to.deep.equal(expected_pktBufs);
+
+            // re-parse to cross-check
+            var parsed = lora_packet.fromWire(expected_pktBufs.PHYPayload);
+            expect(parsed.getBuffers()).to.deep.equal(expected_pktBufs);
+        });
+
+        it('should create join accept packet with CFList', function () {
+            var packet = lora_packet.fromFields(
+                {
+                    AppNonce: new Buffer('AABBCC', 'hex'),
+                    NetID: new Buffer('AABBCC', 'hex'),
+                    DevAddr: new Buffer('AABBCCDD', 'hex'),
+					DLSettings: new Buffer('12', 'hex'),
+					RxDelay: new Buffer('0F', 'hex'),
+					CFList: new Buffer('11223311223311223311223311223300', 'hex')
+                });
+            var expected_pktBufs = {
+                PHYPayload: new Buffer('20CCBBAACCBBAADDCCBBAA120F11223311223311223311223311223300eeeeeeee', 'hex'),
+                MHDR: new Buffer('20', 'hex'),
+                MIC: new Buffer('EEEEEEEE', 'hex'),
+				AppNonce: new Buffer('AABBCC', 'hex'),
+				NetID: new Buffer('AABBCC', 'hex'),
+				DevAddr: new Buffer('AABBCCDD', 'hex'),
+				DLSettings: new Buffer('12', 'hex'),
+				RxDelay: new Buffer('0F', 'hex'),
+				CFList: new Buffer('11223311223311223311223311223300', 'hex')
+            };
+            expect (packet).not.to.be.null;
+            expect(packet.getBuffers()).to.not.be.undefined;
+            expect(packet.getBuffers()).to.deep.equal(expected_pktBufs);
+
+            // re-parse to cross-check
+            var parsed = lora_packet.fromWire(expected_pktBufs.PHYPayload);
+            expect(parsed.getBuffers()).to.deep.equal(expected_pktBufs);
+        });
+
         it('should create packet with correct FPort', function () {
             var packet = lora_packet.fromFields(
                 {

--- a/test/test_construct.js
+++ b/test/test_construct.js
@@ -38,6 +38,7 @@ module.exports = function () {
                 });
             var expected_pktBufs = {
                 PHYPayload: new Buffer('40d4c3b2a10001000174657374eeeeeeee', 'hex'),
+                MACPayloadWithMIC: new Buffer('d4c3b2a10001000174657374eeeeeeee', 'hex'),
                 MHDR: new Buffer('40', 'hex'),
                 MACPayload: new Buffer('d4c3b2a10001000174657374', 'hex'),
                 MIC: new Buffer('EEEEEEEE', 'hex'),
@@ -66,6 +67,7 @@ module.exports = function () {
                 });
             var expected_pktBufs = {
                 PHYPayload: new Buffer('40d4c3b2a1000100eeeeeeee', 'hex'),
+                MACPayloadWithMIC: new Buffer('d4c3b2a1000100eeeeeeee', 'hex'),
                 MHDR: new Buffer('40', 'hex'),
                 MACPayload: new Buffer('d4c3b2a1000100', 'hex'),
                 MIC: new Buffer('EEEEEEEE', 'hex'),
@@ -97,6 +99,7 @@ module.exports = function () {
                 });
             var expected_pktBufs = {
                 PHYPayload: new Buffer('A0d4c3b2a10001000174657374eeeeeeee', 'hex'),
+                MACPayloadWithMIC: new Buffer('d4c3b2a10001000174657374eeeeeeee', 'hex'),
                 MHDR: new Buffer('A0', 'hex'),
                 MACPayload: new Buffer('d4c3b2a10001000174657374', 'hex'),
                 MIC: new Buffer('EEEEEEEE', 'hex'),
@@ -126,6 +129,7 @@ module.exports = function () {
                 });
             var expected_pktBufs = {
                 PHYPayload: new Buffer('80d4c3b2a10001000174657374eeeeeeee', 'hex'),
+                MACPayloadWithMIC: new Buffer('d4c3b2a10001000174657374eeeeeeee', 'hex'),
                 MHDR: new Buffer('80', 'hex'),
                 MACPayload: new Buffer('d4c3b2a10001000174657374', 'hex'),
                 MIC: new Buffer('EEEEEEEE', 'hex'),
@@ -157,6 +161,7 @@ module.exports = function () {
                 });
             var expected_pktBufs = {
                 PHYPayload: new Buffer('40d4c3b2a10034120174657374eeeeeeee', 'hex'),
+                MACPayloadWithMIC: new Buffer('d4c3b2a10034120174657374eeeeeeee', 'hex'),
                 MHDR: new Buffer('40', 'hex'),
                 MACPayload: new Buffer('d4c3b2a10034120174657374', 'hex'),
                 MIC: new Buffer('EEEEEEEE', 'hex'),
@@ -187,6 +192,7 @@ module.exports = function () {
                 });
             var expected_pktBufs = {
                 PHYPayload: new Buffer('40d4c3b2a10034120174657374eeeeeeee', 'hex'),
+                MACPayloadWithMIC: new Buffer('d4c3b2a10034120174657374eeeeeeee', 'hex'),
                 MHDR: new Buffer('40', 'hex'),
                 MACPayload: new Buffer('d4c3b2a10034120174657374', 'hex'),
                 MIC: new Buffer('EEEEEEEE', 'hex'),
@@ -217,6 +223,7 @@ module.exports = function () {
                 });
             var expected_pktBufs = {
                 PHYPayload: new Buffer('40d4c3b2a1040100F0F1F2F30174657374eeeeeeee', 'hex'),
+                MACPayloadWithMIC: new Buffer('d4c3b2a1040100F0F1F2F30174657374eeeeeeee', 'hex'),
                 MHDR: new Buffer('40', 'hex'),
                 MACPayload: new Buffer('d4c3b2a1040100F0F1F2F30174657374', 'hex'),
                 MIC: new Buffer('EEEEEEEE', 'hex'),
@@ -299,11 +306,13 @@ module.exports = function () {
                 });
             var expected_pktBufs = {
                 PHYPayload: new Buffer('00DDCCBBAADDCCBBAADDCCBBAADDCCBBAABBAAeeeeeeee', 'hex'),
+                MACPayloadWithMIC: new Buffer('DDCCBBAADDCCBBAADDCCBBAADDCCBBAABBAAeeeeeeee', 'hex'),
                 MHDR: new Buffer('00', 'hex'),
+                MACPayload: new Buffer('DDCCBBAADDCCBBAADDCCBBAADDCCBBAABBAA', 'hex'),
                 MIC: new Buffer('EEEEEEEE', 'hex'),
-				AppEUI: new Buffer('AABBCCDDAABBCCDD', 'hex'),
-				DevEUI: new Buffer('AABBCCDDAABBCCDD', 'hex'),
-				DevNonce: new Buffer('AABB', 'hex')
+                AppEUI: new Buffer('AABBCCDDAABBCCDD', 'hex'),
+                DevEUI: new Buffer('AABBCCDDAABBCCDD', 'hex'),
+                DevNonce: new Buffer('AABB', 'hex')
             };
             expect(packet).not.to.be.null;
             expect(packet.getBuffers()).to.not.be.undefined;
@@ -323,14 +332,16 @@ module.exports = function () {
                 });
             var expected_pktBufs = {
                 PHYPayload: new Buffer('20CCBBAACCBBAADDCCBBAA0000eeeeeeee', 'hex'),
+                MACPayloadWithMIC: new Buffer('CCBBAACCBBAADDCCBBAA0000eeeeeeee', 'hex'),
                 MHDR: new Buffer('20', 'hex'),
+                MACPayload: new Buffer('CCBBAACCBBAADDCCBBAA0000', 'hex'),
                 MIC: new Buffer('EEEEEEEE', 'hex'),
-				AppNonce: new Buffer('AABBCC', 'hex'),
-				NetID: new Buffer('AABBCC', 'hex'),
-				DevAddr: new Buffer('AABBCCDD', 'hex'),
-				DLSettings: new Buffer('00', 'hex'),
-				RxDelay: new Buffer('00', 'hex'),
-				CFList: new Buffer(0)
+                AppNonce: new Buffer('AABBCC', 'hex'),
+                NetID: new Buffer('AABBCC', 'hex'),
+                DevAddr: new Buffer('AABBCCDD', 'hex'),
+                DLSettings: new Buffer('00', 'hex'),
+                RxDelay: new Buffer('00', 'hex'),
+                CFList: new Buffer(0)
             };
             expect (packet).not.to.be.null;
             expect(packet.getBuffers()).to.not.be.undefined;
@@ -347,19 +358,21 @@ module.exports = function () {
                     AppNonce: new Buffer('AABBCC', 'hex'),
                     NetID: new Buffer('AABBCC', 'hex'),
                     DevAddr: new Buffer('AABBCCDD', 'hex'),
-					DLSettings: new Buffer('12', 'hex'),
-					RxDelay: new Buffer('0F', 'hex')
+                    DLSettings: new Buffer('12', 'hex'),
+                    RxDelay: new Buffer('0F', 'hex')
                 });
             var expected_pktBufs = {
                 PHYPayload: new Buffer('20CCBBAACCBBAADDCCBBAA120Feeeeeeee', 'hex'),
+                MACPayloadWithMIC: new Buffer('CCBBAACCBBAADDCCBBAA120Feeeeeeee', 'hex'),
                 MHDR: new Buffer('20', 'hex'),
+                MACPayload: new Buffer('CCBBAACCBBAADDCCBBAA120F', 'hex'),
                 MIC: new Buffer('EEEEEEEE', 'hex'),
-				AppNonce: new Buffer('AABBCC', 'hex'),
-				NetID: new Buffer('AABBCC', 'hex'),
-				DevAddr: new Buffer('AABBCCDD', 'hex'),
-				DLSettings: new Buffer('12', 'hex'),
-				RxDelay: new Buffer('0F', 'hex'),
-				CFList: new Buffer(0)
+                AppNonce: new Buffer('AABBCC', 'hex'),
+                NetID: new Buffer('AABBCC', 'hex'),
+                DevAddr: new Buffer('AABBCCDD', 'hex'),
+                DLSettings: new Buffer('12', 'hex'),
+                RxDelay: new Buffer('0F', 'hex'),
+                CFList: new Buffer(0)
             };
             expect (packet).not.to.be.null;
             expect(packet.getBuffers()).to.not.be.undefined;
@@ -376,20 +389,22 @@ module.exports = function () {
                     AppNonce: new Buffer('AABBCC', 'hex'),
                     NetID: new Buffer('AABBCC', 'hex'),
                     DevAddr: new Buffer('AABBCCDD', 'hex'),
-					DLSettings: new Buffer('12', 'hex'),
-					RxDelay: new Buffer('0F', 'hex'),
-					CFList: new Buffer('11223311223311223311223311223300', 'hex')
+                    DLSettings: new Buffer('12', 'hex'),
+                    RxDelay: new Buffer('0F', 'hex'),
+                    CFList: new Buffer('11223311223311223311223311223300', 'hex')
                 });
             var expected_pktBufs = {
                 PHYPayload: new Buffer('20CCBBAACCBBAADDCCBBAA120F11223311223311223311223311223300eeeeeeee', 'hex'),
+                MACPayloadWithMIC: new Buffer('CCBBAACCBBAADDCCBBAA120F11223311223311223311223311223300eeeeeeee', 'hex'),
                 MHDR: new Buffer('20', 'hex'),
+                MACPayload: new Buffer('CCBBAACCBBAADDCCBBAA120F11223311223311223311223311223300', 'hex'),
                 MIC: new Buffer('EEEEEEEE', 'hex'),
-				AppNonce: new Buffer('AABBCC', 'hex'),
-				NetID: new Buffer('AABBCC', 'hex'),
-				DevAddr: new Buffer('AABBCCDD', 'hex'),
-				DLSettings: new Buffer('12', 'hex'),
-				RxDelay: new Buffer('0F', 'hex'),
-				CFList: new Buffer('11223311223311223311223311223300', 'hex')
+                AppNonce: new Buffer('AABBCC', 'hex'),
+                NetID: new Buffer('AABBCC', 'hex'),
+                DevAddr: new Buffer('AABBCCDD', 'hex'),
+                DLSettings: new Buffer('12', 'hex'),
+                RxDelay: new Buffer('0F', 'hex'),
+                CFList: new Buffer('11223311223311223311223311223300', 'hex')
             };
             expect (packet).not.to.be.null;
             expect(packet.getBuffers()).to.not.be.undefined;
@@ -411,18 +426,19 @@ module.exports = function () {
         });
 
 
-        it('should calculate MIC if NwkSKey provided', function () {
+        it('should calculate MIC if keys provided', function () {
             var packet = lora_packet.fromFields(
                 {
-                    payload: new Buffer('95437876', 'hex'),
+                    payload: 'test',
                     DevAddr: new Buffer('49be7df1', 'hex'),
                     FCnt: new Buffer('0002', 'hex')
                 }
-                , null  // AppSKey
-                , new Buffer("44024241ed4ce9a68c6a8bc055233fd3", 'hex')
+                , new Buffer("ec925802ae430ca77fd3dd73cb2cc588", 'hex') // AppSKey
+                , new Buffer("44024241ed4ce9a68c6a8bc055233fd3", 'hex') // NwkSKey
             );
             var expected_pktBufs = {
                 PHYPayload: new Buffer('40f17dbe4900020001954378762b11ff0d', 'hex'),
+                MACPayloadWithMIC: new Buffer('f17dbe4900020001954378762b11ff0d', 'hex'),
                 MHDR: new Buffer('40', 'hex'),
                 MACPayload: new Buffer('f17dbe490002000195437876', 'hex'),
                 MIC: new Buffer('2b11ff0d', 'hex'),
@@ -455,6 +471,7 @@ module.exports = function () {
             );
             var expected_pktBufs = {
                 PHYPayload: new Buffer('40f17dbe4900020001954378762b11ff0d', 'hex'),
+                MACPayloadWithMIC: new Buffer('f17dbe4900020001954378762b11ff0d', 'hex'),
                 MHDR: new Buffer('40', 'hex'),
                 MACPayload: new Buffer('f17dbe490002000195437876', 'hex'),
                 MIC: new Buffer('2b11ff0d', 'hex'),
@@ -475,7 +492,6 @@ module.exports = function () {
             var parsed = lora_packet.fromWire(expected_pktBufs.PHYPayload);
             expect(parsed.getBuffers()).to.deep.equal(expected_pktBufs);
         });
-
 
     });
 };

--- a/test/test_keygen.js
+++ b/test/test_keygen.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var lora_packet = require('..');
+var expect = require("chai").expect;
+var assert = require('chai').assert;
+
+module.exports = function () {
+
+    describe('generate session keys', function () {
+
+        it('should generate valid session keys', function () {
+            var AppKey_hex = "98929b92c49edba9676d646d3b612456";
+            var NetID_hex = "aabbcc";
+            var AppNonce_hex = "376338";
+            var DevNonce_hex = "f18e";
+            var sessionKeys = lora_packet.generateSessionKeys(
+                new Buffer(AppKey_hex, 'hex'), new Buffer(NetID_hex, 'hex'), new Buffer(AppNonce_hex, 'hex'), new Buffer(DevNonce_hex, 'hex')
+            );
+            expect(sessionKeys).to.not.be.undefined;
+            expect(sessionKeys.NwkSKey.toString('hex')).to.equal('4e3d6e6afbcc67af2ba3c8e8ec4acf4b');
+            expect(sessionKeys.AppSKey.toString('hex')).to.equal('610897aa6f1460623443b527d3ac6a9d');
+        });
+
+    });
+};
+

--- a/test/test_mic.js
+++ b/test/test_mic.js
@@ -10,7 +10,7 @@ module.exports = function () {
 
     describe('MIC checks', function () {
 
-        it('should calculate & verify correct MIC', function () {
+        it('should calculate & verify correct data packet MIC', function () {
             var message_hex = "40F17DBE4900020001954378762B11FF0D";
             var packet = lora_packet.fromWire(new Buffer(message_hex, 'hex'));
 
@@ -21,7 +21,7 @@ module.exports = function () {
             expect(lora_packet.verifyMIC(packet, new Buffer(NwkSKey_hex, 'hex'))).to.equal(true);
         });
 
-        it('should calculate & verify correct MIC', function () {
+        it('should calculate & verify correct data packet MIC', function () {
             var message_hex = "40F17DBE49000300012A3518AF";
             var packet = lora_packet.fromWire(new Buffer(message_hex, 'hex'));
 
@@ -32,7 +32,7 @@ module.exports = function () {
             expect(lora_packet.verifyMIC(packet, new Buffer(NwkSKey_hex, 'hex'))).to.equal(true);
         });
 
-        it('should detect incorrect MIC', function () {
+        it('should detect incorrect data packet MIC', function () {
             // bodged MIC so it's different
             var message_hex = "40F17DBE49000300012A3518AA"; // aa not af
             var packet = lora_packet.fromWire(new Buffer(message_hex, 'hex'));
@@ -44,7 +44,7 @@ module.exports = function () {
             expect(lora_packet.verifyMIC(packet, new Buffer(NwkSKey_hex, 'hex'))).to.equal(false);
         });
 
-        it('should calculate & verify correct MIC for ACK', function () {
+        it('should calculate & verify correct data packet MIC for ACK', function () {
             var message_hex = "60f17dbe4920020001f9d65d27";
             var packet = lora_packet.fromWire(new Buffer(message_hex, 'hex'));
 
@@ -55,7 +55,7 @@ module.exports = function () {
             expect(lora_packet.verifyMIC(packet, new Buffer(NwkSKey_hex, 'hex'))).to.equal(true);
         });
 
-        it('recalculateMIC should calculate & overwrite existing MIC', function () {
+        it('recalculateMIC should calculate & overwrite existing data packet MIC', function () {
             var message_hex = "60f17dbe4920020001f9d65d27";
             var packet = lora_packet.fromWire(new Buffer(message_hex, 'hex'));
 
@@ -71,6 +71,52 @@ module.exports = function () {
             lora_packet.recalculateMIC(packet, NwkSKey);
             expect(lora_packet.verifyMIC(packet, NwkSKey)).to.equal(true);
             expect(packet.getBuffers().MIC).to.deep.equal(new Buffer('f9d65d27', 'hex'));
+        });
+
+        it('should calculate & verify correct join request packet MIC', function () {
+            var message_hex = "0039363463336913AA05693574323831330489C65B1304";
+            var packet = lora_packet.fromWire(new Buffer(message_hex, 'hex'));
+
+            var AppKey_hex = "98929b92c49edba9676d646d3b612456";
+            var calculatedMIC = lora_packet.calculateMIC(packet, null, new Buffer(AppKey_hex, 'hex'));
+            expect(calculatedMIC.toString('hex')).to.equal('c65b1304');
+
+            expect(lora_packet.verifyMIC(packet, null, new Buffer(AppKey_hex, 'hex'))).to.equal(true);
+        });
+
+        it('should detect incorrect join request packet MIC', function () {
+            // bodged MIC so it's different
+            var message_hex = "0039363463336913AA05693574323831330489C65B1305"; // 05 not 04
+            var packet = lora_packet.fromWire(new Buffer(message_hex, 'hex'));
+
+            var AppKey_hex = "98929b92c49edba9676d646d3b612456";
+            var calculatedMIC = lora_packet.calculateMIC(packet, null, new Buffer(AppKey_hex, 'hex'));
+            expect(calculatedMIC.toString('hex')).to.equal('c65b1304');
+
+            expect(lora_packet.verifyMIC(packet, null, new Buffer(AppKey_hex, 'hex'))).to.equal(false);
+        });
+
+        it('should calculate & verify correct join accept packet MIC', function () {
+            var message_hex = "20386337CCBBAAE7CD2C010000D9D0A6E7"; // not encrypted
+            var packet = lora_packet.fromWire(new Buffer(message_hex, 'hex'));
+
+            var AppKey_hex = "98929b92c49edba9676d646d3b612456";
+            var calculatedMIC = lora_packet.calculateMIC(packet, null, new Buffer(AppKey_hex, 'hex'));
+            expect(calculatedMIC.toString('hex')).to.equal('d9d0a6e7');
+
+            expect(lora_packet.verifyMIC(packet, null, new Buffer(AppKey_hex, 'hex'))).to.equal(true);
+        });
+
+        it('should detect incorrect join accept packet MIC', function () {
+            // bodged MIC so it's different
+            var message_hex = "20386337CCBBAAE7CD2C010000D9D0A6E8"; // E8 not E7, not encrypted
+            var packet = lora_packet.fromWire(new Buffer(message_hex, 'hex'));
+
+            var AppKey_hex = "98929b92c49edba9676d646d3b612456";
+            var calculatedMIC = lora_packet.calculateMIC(packet, null, new Buffer(AppKey_hex, 'hex'));
+            expect(calculatedMIC.toString('hex')).to.equal('d9d0a6e7');
+
+            expect(lora_packet.verifyMIC(packet, null, new Buffer(AppKey_hex, 'hex'))).to.equal(false);
         });
 
     });

--- a/test/test_parse.js
+++ b/test/test_parse.js
@@ -9,11 +9,12 @@ module.exports = function () {
     // TODO more variation on this
 
     describe('parse example packet', function () {
-        it('should parse packet', function () {
+        it('should parse data packet', function () {
             var message_hex = "40F17DBE4900020001954378762B11FF0D";
 
             var expected_pktBufs = {
                 PHYPayload: new Buffer('40f17dbe4900020001954378762b11ff0d', 'hex'),
+                MACPayloadWithMIC: new Buffer('f17dbe4900020001954378762b11ff0d', 'hex'),
                 MHDR: new Buffer('40', 'hex'),
                 MACPayload: new Buffer('f17dbe490002000195437876', 'hex'),
                 MIC: new Buffer('2b11ff0d', 'hex'),
@@ -40,13 +41,63 @@ module.exports = function () {
             expect(parsed.getFCtrlADR()).to.equal(false);
         });
 
+        it('should parse join request packet', function () {
+            var message_hex = "0039363463336913AA05693574323831338EF1C1D5EC6C";
 
+            var expected_pktBufs = {
+                PHYPayload: new Buffer('0039363463336913aa05693574323831338ef1c1d5ec6c', 'hex'),
+                MACPayloadWithMIC: new Buffer('39363463336913aa05693574323831338ef1c1d5ec6c', 'hex'),
+                MHDR: new Buffer('00', 'hex'),
+                MACPayload: new Buffer('39363463336913aa05693574323831338ef1', 'hex'),
+                MIC: new Buffer('c1d5ec6c', 'hex'),
+                AppEUI: new Buffer('aa13693363343639', 'hex'),
+                DevEUI: new Buffer('3331383274356905', 'hex'),
+                DevNonce: new Buffer('f18e', 'hex')
+            };
 
-        it('should parse packet with empty payload', function () {
+            var parsed = lora_packet.fromWire(new Buffer(message_hex, 'hex'));
+
+            expect(parsed).to.not.be.undefined;
+            expect(parsed.getBuffers()).to.not.be.undefined;
+            expect(parsed.getBuffers()).to.deep.equal(expected_pktBufs);
+
+            // non-buffer output
+            expect(parsed.getMType()).to.equal('Join Request');
+        });
+
+        it('should parse join accept packet', function () {
+            var message_hex = "20386337CCBBAAE7CD2C010000D9D0A6E7"; // not encrypted
+
+            var expected_pktBufs = {
+                PHYPayload: new Buffer('20386337ccbbaae7cd2c010000d9d0a6e7', 'hex'),
+                MACPayloadWithMIC: new Buffer('386337ccbbaae7cd2c010000d9d0a6e7', 'hex'),
+                MHDR: new Buffer('20', 'hex'),
+                MACPayload: new Buffer('386337ccbbaae7cd2c010000', 'hex'),
+                MIC: new Buffer('d9d0a6e7', 'hex'),
+                NetID: new Buffer('aabbcc', 'hex'),
+                DevAddr: new Buffer('012ccde7', 'hex'),
+                AppNonce: new Buffer('376338', 'hex'),
+                DLSettings: new Buffer('00', 'hex'),
+                RxDelay: new Buffer('00', 'hex'),
+                CFList: new Buffer('', 'hex')
+            };
+
+            var parsed = lora_packet.fromWire(new Buffer(message_hex, 'hex'));
+
+            expect(parsed).to.not.be.undefined;
+            expect(parsed.getBuffers()).to.not.be.undefined;
+            expect(parsed.getBuffers()).to.deep.equal(expected_pktBufs);
+
+            // non-buffer output
+            expect(parsed.getMType()).to.equal('Join Accept');
+        });
+
+        it('should parse data packet with empty payload', function () {
             var message_hex = "40F17DBE49000300012A3518AF";
 
             var expected_pktBufs = {
                 PHYPayload: new Buffer('40f17dbe49000300012a3518af', 'hex'),
+                MACPayloadWithMIC: new Buffer('f17dbe49000300012a3518af', 'hex'),
                 MHDR: new Buffer('40', 'hex'),
                 MACPayload: new Buffer('f17dbe4900030001', 'hex'),
                 MIC: new Buffer('2a3518af', 'hex'),
@@ -73,11 +124,12 @@ module.exports = function () {
             expect(parsed.getFCtrlADR()).to.equal(false);
         });
 
-        it('should parse large packet', function () {
+        it('should parse large data packet', function () {
             var message_hex = "40f17dbe490004000155332de41a11adc072553544429ce7787707d1c316e027e7e5e334263376affb8aa17ad30075293f28dea8a20af3c5e7";
 
             var expected_pktBufs = {
                 PHYPayload: new Buffer('40f17dbe490004000155332de41a11adc072553544429ce7787707d1c316e027e7e5e334263376affb8aa17ad30075293f28dea8a20af3c5e7', 'hex'),
+                MACPayloadWithMIC: new Buffer('f17dbe490004000155332de41a11adc072553544429ce7787707d1c316e027e7e5e334263376affb8aa17ad30075293f28dea8a20af3c5e7', 'hex'),
                 MHDR: new Buffer('40', 'hex'),
                 MACPayload: new Buffer('f17dbe490004000155332de41a11adc072553544429ce7787707d1c316e027e7e5e334263376affb8aa17ad30075293f28dea8a2', 'hex'),
                 MIC: new Buffer('0af3c5e7', 'hex'),
@@ -110,6 +162,7 @@ module.exports = function () {
 
             var expected_pktBufs = {
                 PHYPayload: new Buffer('60f17dbe4920020001f9d65d27', 'hex'),
+                MACPayloadWithMIC: new Buffer('f17dbe4920020001f9d65d27', 'hex'),
                 MHDR: new Buffer('60', 'hex'),
                 MACPayload: new Buffer('f17dbe4920020001', 'hex'),
                 MIC: new Buffer('f9d65d27', 'hex'),

--- a/test/unittest.js
+++ b/test/unittest.js
@@ -5,4 +5,5 @@ describe("unit tests", function () {
     require('./test_construct.js')();
     require('./test_mic.js')();
     require('./test_decrypt.js')();
+    require('./test_keygen.js')();
 });


### PR DESCRIPTION
I have added full support for join packets, both join request and join accept and both encryption and MIC generation. I have also added a session key generator that can be used for OTAA handshaking.

I have added some extra unit tests for the new functionality. I have changed the unit test for MIC generation when only a NwkSKey is provided to have both the NwkSKey and the AppSKey, as the specification states that for data packets the packet must be encrypted before the MIC is generated and therefore a MIC of a not encrypted packet is invalid. For the unit tests, all expected MICs, etc are retrieved from/matched against a certified LoRaWAN stack implementation, thus ensuring the expected values are correct.

Furthermore, I have changed the behavior of the packet constructor to throw exceptions on errors instead of returning null. I personally dislike returning null when there is an error as it makes determining the cause of the error very difficult.

