### PR TITLE
Parse RFU and proprietary  packets

### DIFF
--- a/__tests__/parse_test.ts
+++ b/__tests__/parse_test.ts
@@ -225,4 +225,38 @@ describe("parse example payload", () => {
     expect(parsed.getRxDelayDel()).toBe(2);
     expect(parsed.getFCnt()).toBe(null);
   });
+
+  it("should parse proprietary packets", () => {
+    const message_hex = "E0008B658839";
+
+    const expectedPayload = {
+      PHYPayload: Buffer.from("E0008B658839", "hex"),
+      MACPayloadWithMIC: Buffer.from("008B658839", "hex"),
+      MHDR: Buffer.from("E0", "hex"),
+      MACPayload: Buffer.from("00", "hex"),
+      MIC: Buffer.from("8B658839", "hex"),
+    };
+
+    const parsed = LoraPayload.fromWire(Buffer.from(message_hex, "hex"));
+
+    expect(parsed).toMatchObject(expectedPayload);
+    expect(parsed.getMType()).toBe("Proprietary");
+  })
+
+  it("should parse RFU packets", () => {
+    const message_hex = "C0008B658839";
+
+    const expectedPayload = {
+      PHYPayload: Buffer.from("C0008B658839", "hex"),
+      MACPayloadWithMIC: Buffer.from("008B658839", "hex"),
+      MHDR: Buffer.from("C0", "hex"),
+      MACPayload: Buffer.from("00", "hex"),
+      MIC: Buffer.from("8B658839", "hex"),
+    };
+
+    const parsed = LoraPayload.fromWire(Buffer.from(message_hex, "hex"));
+
+    expect(parsed).toMatchObject(expectedPayload);
+    expect(parsed.getMType()).toBe("RFU");
+  })
 });

--- a/src/lib/LoraPacket.ts
+++ b/src/lib/LoraPacket.ts
@@ -118,18 +118,16 @@ class LoraPacket {
 
     this.MHDR = incoming.slice(0, 1);
     this.MACPayload = incoming.slice(1, incoming.length - 4);
+    this.MACPayloadWithMIC = incoming.slice(1, incoming.length);
+    this.MIC = incoming.slice(incoming.length - 4);
 
     const mtype = this._getMType();
 
     if (mtype == MType.JOIN_REQUEST) {
-      this.MACPayloadWithMIC = incoming.slice(1, incoming.length);
       this.AppEUI = reverseBuffer(incoming.slice(1, 1 + 8));
       this.DevEUI = reverseBuffer(incoming.slice(9, 9 + 8));
       this.DevNonce = reverseBuffer(incoming.slice(17, 17 + 2));
-      this.MIC = incoming.slice(incoming.length - 4);
     } else if (mtype == MType.JOIN_ACCEPT) {
-      this.MACPayload = incoming.slice(1, incoming.length - 4);
-      this.MACPayloadWithMIC = incoming.slice(1, incoming.length);
       this.AppNonce = reverseBuffer(incoming.slice(1, 1 + 3));
       this.NetID = reverseBuffer(incoming.slice(4, 4 + 3));
       this.DevAddr = reverseBuffer(incoming.slice(7, 7 + 4));
@@ -141,12 +139,7 @@ class LoraPacket {
       } else {
         this.CFList = Buffer.alloc(0);
       }
-      this.MIC = incoming.slice(incoming.length - 4);
     } else if (this.isDataMessage()) {
-      this.MACPayload = incoming.slice(1, incoming.length - 4);
-      this.MACPayloadWithMIC = incoming.slice(1, incoming.length);
-      this.MIC = incoming.slice(incoming.length - 4);
-
       this.FCtrl = this.MACPayload.slice(4, 5);
       const FCtrl = this.FCtrl.readInt8(0);
       const FOptsLen = FCtrl & 0x0f;


### PR DESCRIPTION
For RFU (Mtype=110) or proprietary (Mtype=111), the MHDR, MacPayload and MIC parts of the PHYPayload could be decoded.