### PR TITLE
Fix Buffer deprecated message

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [10.x, 12.x, 14.x, 16.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1572,9 +1572,9 @@
       }
     },
     "@types/crypto-js": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.0.0.tgz",
-      "integrity": "sha512-PxWOv3cj3XbRdwxwq7505AdQ4ZirnZRPddPq254SDMinhDUGLzk7V7fd5K47nXMJYzE6w2f0GXtmohTUMGp7bA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@types/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-BG7fQKZ689HIoc5h+6D2Dgq1fABRa0RbBWKBd9SP/MVRVXROflpm5fhwyATX5duFmbStzyzyycPB8qUYKDH3NA==",
       "dev": true
     },
     "@types/graceful-fs": {
@@ -2498,9 +2498,9 @@
       }
     },
     "crypto-js": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.0.0.tgz",
-      "integrity": "sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
     },
     "cssom": {
       "version": "0.4.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1907,6 +1907,11 @@
       "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
       "dev": true
     },
+    "aes-cmac": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/aes-cmac/-/aes-cmac-1.0.3.tgz",
+      "integrity": "sha512-D201msdnHbQlkw91uqjD5h0LtX//R2fRAh/f2tOs1C96J7QuIRn4b7aeN1mKZsO5No4H+MarABanapDdvCYayg=="
+    },
     "agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -5095,11 +5100,6 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
-    },
-    "node-aes-cmac": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/node-aes-cmac/-/node-aes-cmac-0.1.1.tgz",
-      "integrity": "sha1-m//4ay9j45SeKCi9hfW2gltwKEQ="
     },
     "node-int64": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
   },
   "dependencies": {
     "aes-cmac": "1.0.3",
-    "crypto-js": "4.0.0"
+    "crypto-js": "4.1.1"
   },
   "license": "MIT",
   "devDependencies": {
-    "@types/crypto-js": "4.0.0",
+    "@types/crypto-js": "4.1.1",
     "@types/node": "14.11.8",
     "@typescript-eslint/eslint-plugin": "4.4.0",
     "@typescript-eslint/parser": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "lora-packet-decode": "./out/cli.js"
   },
   "dependencies": {
-    "crypto-js": "4.0.0",
-    "node-aes-cmac": "0.1.1"
+    "aes-cmac": "1.0.3",
+    "crypto-js": "4.0.0"
   },
   "license": "MIT",
   "devDependencies": {

--- a/src/lib/mic.ts
+++ b/src/lib/mic.ts
@@ -1,8 +1,7 @@
 import LoraPacket from "./LoraPacket";
 import { reverseBuffer } from "./util";
 
-// @ts-ignore
-import { aesCmac } from "node-aes-cmac";
+import { AesCmac } from "aes-cmac";
 
 // calculate MIC from payload
 function calculateMIC(payload: LoraPacket, NwkSKey?: Buffer, AppKey?: Buffer, FCntMSBytes?: Buffer): Buffer {
@@ -21,7 +20,7 @@ function calculateMIC(payload: LoraPacket, NwkSKey?: Buffer, AppKey?: Buffer, FC
     const cmacInput = Buffer.concat([payload.MHDR, payload.MACPayload]);
 
     // CMAC calculation (as RFC4493)
-    let fullCmac = aesCmac(AppKey, cmacInput, { returnAsBuffer: true });
+    let fullCmac = new AesCmac(AppKey).calculate(cmacInput);
     if (!(fullCmac instanceof Buffer)) fullCmac = Buffer.from(fullCmac);
     // only first 4 bytes of CMAC are used as MIC
     const MIC = fullCmac.slice(0, 4);
@@ -52,7 +51,7 @@ function calculateMIC(payload: LoraPacket, NwkSKey?: Buffer, AppKey?: Buffer, FC
     const cmacInput = Buffer.concat([payload.MHDR, payload.MACPayload]);
 
     // CMAC calculation (as RFC4493)
-    let fullCmac = aesCmac(AppKey, cmacInput, { returnAsBuffer: true });
+    let fullCmac = new AesCmac(AppKey).calculate(cmacInput);
     if (!(fullCmac instanceof Buffer)) fullCmac = Buffer.from(fullCmac);
     // only first 4 bytes of CMAC are used as MIC
     const MIC = fullCmac.slice(0, 4);
@@ -96,7 +95,7 @@ function calculateMIC(payload: LoraPacket, NwkSKey?: Buffer, AppKey?: Buffer, FC
     const cmacInput = Buffer.concat([B0, payload.MHDR, payload.MACPayload]);
 
     // CMAC calculation (as RFC4493)
-    let fullCmac = aesCmac(NwkSKey, cmacInput, { returnAsBuffer: true });
+    let fullCmac = new AesCmac(NwkSKey).calculate(cmacInput);
     if (!(fullCmac instanceof Buffer)) fullCmac = Buffer.from(fullCmac);
 
     // only first 4 bytes of CMAC are used as MIC


### PR DESCRIPTION
Hi,

This PR solves the deprecation warning message related with buffer constructors. See #79 for more information.

The message warning message comes from node-aes-cmac. This module has not been updated for a year, so to fix this problem the [node-aes-cmac](https://github.com/allan-stewart/node-aes-cmac) was replaced with [aes-cmac](https://www.npmjs.com/package/aes-cmac). The aes-cmac it's a implementation of node-aes-cmac in typescript. 

Changes:
 - Replace [node-aes-cmac](https://github.com/allan-stewart/node-aes-cmac) module with [aes-cmac](https://www.npmjs.com/package/aes-cmac)
 - Update crypto-js to 4.1.1