### PR TITLE
add sanity checks to fromWire buffer lengths

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,10 @@ you'll find helpful.
 
 #### Version history
 
+(unreleased)
+- - sanity checks in fromWire
+- - fix parsing RejoinRequest
+
 - 0.8.24 bump crypto-js to 4.2.0 (CVE-2023-46233)
 - 0.8.23 bump @babel/traverse to 7.23.2
 - 0.8.22 add WOR keys
@@ -355,3 +359,5 @@ you'll find helpful.
 - Thank you to [kalik1](https://github.com/kalik1)
 - Thank you to [Pierre PLR](https://github.com/pplr)
 - Thank you to [Ricardo Stoklosa](https://github.com/RicardoStoklosa)
+- Thank you to [Lucas](https://github.com/aqllmcdavid)
+

--- a/src/lib/LoraPacket.ts
+++ b/src/lib/LoraPacket.ts
@@ -142,10 +142,16 @@ class LoraPacket {
     const mtype = this._getMType();
 
     if (mtype == MType.JOIN_REQUEST) {
+      if (incoming.length < 5 + 18) {
+        throw new Error("contents too short for a Join Request");
+      }
       this.AppEUI = reverseBuffer(incoming.slice(1, 1 + 8));
       this.DevEUI = reverseBuffer(incoming.slice(9, 9 + 8));
       this.DevNonce = reverseBuffer(incoming.slice(17, 17 + 2));
     } else if (mtype == MType.JOIN_ACCEPT) {
+      if (incoming.length < 5 + 12) {
+        throw new Error("contents too short for a Join Accept");
+      }
       this.AppNonce = reverseBuffer(incoming.slice(1, 1 + 3));
       this.NetID = reverseBuffer(incoming.slice(4, 4 + 3));
       this.DevAddr = reverseBuffer(incoming.slice(7, 7 + 4));
@@ -161,10 +167,16 @@ class LoraPacket {
     } else if (mtype == MType.REJOIN_REQUEST) {
       this.RejoinType = incoming.slice(1, 1 + 1);
       if (this.RejoinType[0] === 0 || this.RejoinType[0] === 2) {
+        if (incoming.length < 5 + 14) {
+          throw new Error("contents too short for a Rejoin Request (Type 0/2)");
+        }
         this.NetID = reverseBuffer(incoming.slice(2, 2 + 3));
         this.DevEUI = reverseBuffer(incoming.slice(5, 5 + 8));
         this.RJCount0 = reverseBuffer(incoming.slice(13, 13 + 2));
       } else if (this.RejoinType[0] === 1) {
+        if (incoming.length < 5 + 19) {
+          throw new Error("contents too short for a Rejoin Request (Type 1)");
+        }
         this.JoinEUI = reverseBuffer(incoming.slice(2, 2 + 8));
         this.DevEUI = reverseBuffer(incoming.slice(10, 10 + 8));
         this.RJCount1 = reverseBuffer(incoming.slice(18, 18 + 2));


### PR DESCRIPTION
fromWire() should throw a (helpful) error if given a buffer that's too small, not just silently continue

fixes #114