### PR TITLE
Modify the project to utilize Buffer from globalThis instead of requiring it.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,12 +8,12 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x, 18.x]
+        node-version: [10.x, 12.x, 14.x, 16.x, 18.x, 20.x, 22.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci

--- a/src/lib/LoraPacket.ts
+++ b/src/lib/LoraPacket.ts
@@ -1,7 +1,6 @@
 import { reverseBuffer, asHexString } from "./util";
 import { decrypt, decryptJoin, decryptFOpts } from "./crypto";
 import { recalculateMIC } from "./mic";
-import { Buffer } from "buffer";
 
 enum MType {
   JOIN_REQUEST = 0,

--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -1,7 +1,6 @@
-import LoraPacket, { LorawanVersion } from "./LoraPacket";
+import LoraPacket from "./LoraPacket";
 import { reverseBuffer } from "./util";
 import CryptoJS from "crypto-js";
-import { Buffer } from "buffer";
 
 const LORAIV = CryptoJS.enc.Hex.parse("00000000000000000000000000000000");
 

--- a/src/lib/mic.ts
+++ b/src/lib/mic.ts
@@ -2,7 +2,6 @@ import LoraPacket, { LorawanVersion } from "./LoraPacket";
 import { reverseBuffer } from "./util";
 
 import { AesCmac } from "aes-cmac";
-import { Buffer } from "buffer";
 
 // calculate MIC from payload
 function calculateMIC(


### PR DESCRIPTION
This PR removes the requirement for Buffer, now supported on all Node.js versions. Here at [TagoIO](https://github.com/tago-io), we use a custom runtime to run unsafe code, and that library import made it impossible for us to upgrade the version of lora-packet, keeping us on an old version (0.8.15 - that version was using globalThis), because we use a bundle to polyfill buffer dependency.

This change is backward-compatible; all Node.js versions (10.x, 12.x, 14.x, 16.x, 18.x, 20.x, 22.x) are working fine, as you can see in the actions.

In this PR, I also added support for Node 20 and 22 in the CI pipeline.